### PR TITLE
Fixed invalid JSON in documentation

### DIFF
--- a/docs/getting-started/hosting-a-venue-on-openreview/customizing-your-submission-form.md
+++ b/docs/getting-started/hosting-a-venue-on-openreview/customizing-your-submission-form.md
@@ -18,7 +18,7 @@ You can customize the [default submission form](../../reference/default-forms/de
       "value": {
           "param": {
             "type": "profile[]",
-            "regex": "~.*",
+            "regex": "~.*"
           }
       },
       "description": "Please nominate an author to serve as a reviewer using their profile ID (e.g. ~First_Last1)",


### PR DESCRIPTION
Updating the venue with the provided JSON results in an error because the JSON example is not formatted correctly, containing an extraneous comma.