### PR TITLE
"optional" : true makes a field optional and not required

### DIFF
--- a/docs/getting-started/customizing-forms.md
+++ b/docs/getting-started/customizing-forms.md
@@ -94,7 +94,7 @@ The `input` specifier determines the rendering on the form and can have the foll
 
 Validation specifiers are used by the back-end to ensure data submitted through the form conforms to certain requirements. In the example above, only a single string is allowed, and that string must be one of the values defined in the `enum` array. Specifically, a string that has the value "`Test Submission Title`"
 
-`optional` is a boolean (true/false) value that indicates whether or not this field is required to be present when the form is submitted. By default all fields in the form are required, and you can add `optional : true` to indicate a required field.
+`optional` is a boolean (true/false) value that indicates whether or not this field is required to be present when the form is submitted. By default all fields in the form are required, and you can add `optional : true` to indicate an optional field.
 
 {% hint style="info" %}
 Required fields have their field names prefixed with an asterisk


### PR DESCRIPTION
Fixes language.

I should probably ask this via email, but I have the following JSON -
```json
{
    "title": {
        "order": 1,
        "description": "Title of the poster. Add TeX formulas using the following formats: $In-line Formula$ or $$Block Formula$$.",
        "value": {
            "param": {
                "type": "string",
                "markdown": true
            }
        }
    },
    "abstract": {
        "description": "Abstract of poster. Add TeX formulas using the following formats: $In-line Formula$ or $$Block Formula$$.",
        "value": {
            "param": {
                "type": "string",
                "markdown": true,
                "input": "textarea"
            }
        }
    },
    "pdf": {
        "description": "See word and latex templates here - https://github.com/oss-for-surg-med-ai-tech/workshop-hamlyn2025/tree/main/posters/templates. You can also make use of our overleaf templates which anyone with this link can view this project - https://www.overleaf.com/project/681b0323ce3118c8d973aa3f.",
        "value": {
            "param": {
                "type": "file",
                "extensions": [
                    "pdf"
                ],
                "optional": false,
                "maxSize": 200
            }
        }
    }
}
```

with `pdf` as a `"optional": false` field, but [my venue](https://openreview.net/group?id=hamlynsymposium.org/Hamlyn_Symposium/2025/Workshop/OSS_in_SurgTech#tab-recent-activity) still marks it as optional -

<img width="919" alt="image" src="https://github.com/user-attachments/assets/91dc5de0-5205-4c30-b182-1fd73563c462" />

Is this an undocumented behavior?